### PR TITLE
Travis CI: Test only with Ruby 2.5 and 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 rvm:
-  - 2.3.8
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.5.8
+  - 2.6.6
 
 services:
   - postgresql


### PR DESCRIPTION
Hey, 

This PR brings Travis CI up to speed.

No need to keep testing with EOLed Ruby versions (2.3 and 2.4) -- It fixes #33

Please check it out. 

Thanks! 