### PR TITLE
Fix site url in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://travis-ci.org/rubymem/rubymem.com.svg?branch=master)](https://travis-ci.org/rubymem/rubymem.com)
 
-This is the Rails app that powers [RubyMem.com](https://RubyMem.com): A website
+This is the Rails app that powers [RubyMem.com](https://www.RubyMem.com): A website
 to submit new reports about gems which have memory leaks. Also, a nice way to
 browse existing memory leak advisories.
 


### PR DESCRIPTION
I noticed that the RubyMem URL from the README file doesn't work. Adding the `www.` fixes it.

Please check it out. Thanks!